### PR TITLE
[FIX] Auth code not being decoded properly

### DIFF
--- a/source/OAuth2Client.js
+++ b/source/OAuth2Client.js
@@ -1,4 +1,4 @@
-import { stringify } from "query-string";
+import { stringify, parse } from "query-string";
 import { request } from "cowl";
 import EventEmitter from "eventemitter3";
 import {
@@ -46,8 +46,9 @@ export default class OAuth2Client extends EventEmitter {
     }
 
     async exchangeAuthCodeForToken(authCode) {
+        const decodedAuthCode = Object.keys(parse(authCode))[0];
         const data = {
-            code: authCode,
+            code: decodedAuthCode,
             client_id: this._clientID,
             client_secret: this._clientSecret,
             redirect_uri: this._redirectURL,

--- a/source/OAuth2Client.js
+++ b/source/OAuth2Client.js
@@ -1,4 +1,5 @@
-import { stringify, parse } from "query-string";
+import { stringify } from "query-string";
+import { unescape } from "querystring";
 import { request } from "cowl";
 import EventEmitter from "eventemitter3";
 import {
@@ -46,7 +47,7 @@ export default class OAuth2Client extends EventEmitter {
     }
 
     async exchangeAuthCodeForToken(authCode) {
-        const decodedAuthCode = Object.keys(parse(authCode))[0];
+        const decodedAuthCode = unescape(authCode);
         const data = {
             code: decodedAuthCode,
             client_id: this._clientID,

--- a/test/specs/google-oauth2.spec.js
+++ b/test/specs/google-oauth2.spec.js
@@ -73,5 +73,21 @@ describe("google-oauth2", function() {
                 expect(this.tokensListener.firstCall.args[0]).to.have.property("refresh_token", "rt");
             });
         });
+
+        describe("auth code decoding", function() {
+            beforeEach(function() {
+                sinon.spy(this.client, "exchangeAuthCodeForToken")
+            })
+
+            afterEach(function() {
+                this.client.exchangeAuthCodeForToken.restore();
+            })
+
+            it("decodes auth code first before stringifying to be sent in request", function() {
+                const authCode = "4%2FswEmlFcE4vP6BCXY_xmc4kUUgzB3uqB_b9uVLisqrr6-ADVVQEg7a6LojiIkyWq1JY4QhAGWbe5ektjTO";
+                this.client.exchangeAuthCodeForToken(authCode);
+                expect(this.client._request.getCall(0).args[0].body).to.include(authCode);
+            })
+        })
     });
 });

--- a/test/specs/google-oauth2.spec.js
+++ b/test/specs/google-oauth2.spec.js
@@ -76,18 +76,18 @@ describe("google-oauth2", function() {
 
         describe("auth code decoding", function() {
             beforeEach(function() {
-                sinon.spy(this.client, "exchangeAuthCodeForToken")
-            })
+                sinon.spy(this.client, "exchangeAuthCodeForToken");
+            });
 
             afterEach(function() {
                 this.client.exchangeAuthCodeForToken.restore();
-            })
+            });
 
             it("decodes auth code first before stringifying to be sent in request", function() {
                 const authCode = "4%2FswEmlFcE4vP6BCXY_xmc4kUUgzB3uqB_b9uVLisqrr6-ADVVQEg7a6LojiIkyWq1JY4QhAGWbe5ektjTO";
                 this.client.exchangeAuthCodeForToken(authCode);
                 expect(this.client._request.getCall(0).args[0].body).to.include(authCode);
-            })
+            });
         })
     });
 });


### PR DESCRIPTION
The auth code was being encoded 2 times causing an "invalid_grant"
error to be thrown. The fix is to decode the incoming auth token
first before the body object is stringified.

![Screenshot from 2019-11-06 17-01-15](https://user-images.githubusercontent.com/3457571/68284438-809d5b00-00b8-11ea-8d77-dbbf3d14068b.jpg)

Fixes https://github.com/buttercup/buttercup-desktop/issues/835