### PR TITLE
Fix types for token response

### DIFF
--- a/source/types.ts
+++ b/source/types.ts
@@ -1,5 +1,5 @@
 export interface GoogleToken {
     access_token: string;
-    expiry_date: Date;
+    expiry_date: number;
     refresh_token: string;
 }

--- a/source/types.ts
+++ b/source/types.ts
@@ -1,5 +1,5 @@
 export interface GoogleToken {
     access_token: string;
-    expires_in: number;
+    expiry_date: Date;
     refresh_token: string;
 }


### PR DESCRIPTION
Thanks for that wrapper!

You have already converted `expires_in` to `expiry_date`, but the type is still incorrect. Fixed it.