### PR TITLE
Fix Illegal invocation when library used in react app

### DIFF
--- a/source/OAuth2Client.ts
+++ b/source/OAuth2Client.ts
@@ -36,7 +36,7 @@ export class OAuth2Client extends EventEmitter {
         this._accessToken = null;
         this._refreshToken = null;
         this._refreshTokenPromises = new Map();
-        this._fetch = fetch;
+        this._fetch = fetch.bind(window === undefined ? this : window);
     }
 
     get accessToken() {


### PR DESCRIPTION
When this library is used in a react application (especially buttercup-desktop), the following error was triggered when calling `exchangeAuthCodeForToken`:
"Failed to execute 'fetch' on 'Window': Illegal invocation".

You can use your "cross" fetch function as long as you want. But when you use a variable / class field to call this function, you need to bind its `this` context it with `window`. Otherwise it will lose the context of `this` 

This fixes buttercup/buttercup-desktop#1200

Sorry, for the close / reopen. I was sleeping, then I thought I was wrong. But finally I don't think I am

(keep up the great job on buttercup :) this software is amazing :p)